### PR TITLE
Updated to use the new `Pointer#value_with_autorelease` API of RM >=7.6

### DIFF
--- a/lib/motion-sqlite3/database.rb
+++ b/lib/motion-sqlite3/database.rb
@@ -5,7 +5,7 @@ module SQLite3
       @logging = false
 
       result = sqlite3_open(filename, @handle)
-      raise SQLite3Error, sqlite3_errmsg(@handle.value) if result != SQLITE_OK
+      raise SQLite3Error, sqlite3_errmsg(@handle.value_with_autorelease) if result != SQLITE_OK
     end
 
     def execute(sql, params = nil, &block)

--- a/lib/motion-sqlite3/result_set.rb
+++ b/lib/motion-sqlite3/result_set.rb
@@ -18,22 +18,22 @@ module SQLite3
     def current_row
       row = {}
 
-      column_count = sqlite3_column_count(@handle.value)
+      column_count = sqlite3_column_count(@handle.value_with_autorelease)
       0.upto(column_count - 1) do |i|
-        name = sqlite3_column_name(@handle.value, i).to_sym
-        type = sqlite3_column_type(@handle.value, i)
+        name = sqlite3_column_name(@handle.value_with_autorelease, i).to_sym
+        type = sqlite3_column_type(@handle.value_with_autorelease, i)
 
         case type
         when SQLITE_NULL
           row[name] = nil
         when SQLITE_TEXT
-          row[name] = sqlite3_column_text(@handle.value, i)
+          row[name] = sqlite3_column_text(@handle.value_with_autorelease, i)
         when SQLITE_BLOB
-          row[name] = NSData.dataWithBytes(sqlite3_column_blob(@handle.value, i), length: sqlite3_column_bytes(@handle.value, i))
+          row[name] = NSData.dataWithBytes(sqlite3_column_blob(@handle.value_with_autorelease, i), length: sqlite3_column_bytes(@handle.value_with_autorelease, i))
         when SQLITE_INTEGER
-          row[name] = sqlite3_column_int64(@handle.value, i)
+          row[name] = sqlite3_column_int64(@handle.value_with_autorelease, i)
         when SQLITE_FLOAT
-          row[name] = sqlite3_column_double(@handle.value, i)
+          row[name] = sqlite3_column_double(@handle.value_with_autorelease, i)
         end
       end
 

--- a/lib/motion-sqlite3/statement.rb
+++ b/lib/motion-sqlite3/statement.rb
@@ -20,13 +20,13 @@ module SQLite3
     end
 
     def finalize
-      sqlite3_finalize(@handle.value)
+      sqlite3_finalize(@handle.value_with_autorelease)
     end
 
     def step
-      @result = sqlite3_step(@handle.value)
+      @result = sqlite3_step(@handle.value_with_autorelease)
       unless @result == SQLITE_DONE || @result == SQLITE_ROW
-        raise SQLite3Error, sqlite3_errmsg(@db.value)
+        raise SQLite3Error, sqlite3_errmsg(@db.value_with_autorelease)
       end
     end
 
@@ -49,20 +49,20 @@ module SQLite3
 
       case value
       when NilClass
-        result = sqlite3_bind_null(@handle.value, index)
+        result = sqlite3_bind_null(@handle.value_with_autorelease, index)
       when String, Symbol
-        result = sqlite3_bind_text(@handle.value, index, value, -1, lambda { |arg| })
+        result = sqlite3_bind_text(@handle.value_with_autorelease, index, value, -1, lambda { |arg| })
       when Integer
-        result = sqlite3_bind_int64(@handle.value, index, value)
+        result = sqlite3_bind_int64(@handle.value_with_autorelease, index, value)
       when Float
-        result = sqlite3_bind_double(@handle.value, index, value)
-      when NSData
-        result = sqlite3_bind_blob(@handle.value, index, value.bytes, value.length, lambda { |arg| })
+        result = sqlite3_bind_double(@handle.value_with_autorelease, index, value)
+      when NSDatavalue
+        result = sqlite3_bind_blob(@handle.value_with_autorelease, index, value.bytes, value.length, lambda { |arg| })
       else
         raise SQLite3Error, "unable to bind #{value} to #{name}: unexpected type #{value.class}"
       end
 
-      raise SQLite3Error, sqlite3_errmsg(@db.value) if result != SQLITE_OK
+      raise SQLite3Error, sqlite3_errmsg(@db.value_with_autorelease) if result != SQLITE_OK
     end
 
     def column_index(name)
@@ -70,7 +70,7 @@ module SQLite3
 
       case name
       when String, Symbol
-        index = sqlite3_bind_parameter_index(@handle.value, ":#{name}")
+        index = sqlite3_bind_parameter_index(@handle.value_with_autorelease, ":#{name}")
         raise SQLite3Error, "couldn't find index for #{name}!" if index == 0
 
       when Integer
@@ -82,8 +82,8 @@ module SQLite3
 
     def prepare(sql)
       remainder = Pointer.new(:string)
-      result = sqlite3_prepare_v2(@db.value, sql, -1, @handle, remainder)
-      raise SQLite3Error, sqlite3_errmsg(@db.value) if result != SQLITE_OK
+      result = sqlite3_prepare_v2(@db.value_with_autorelease, sql, -1, @handle, remainder)
+      raise SQLite3Error, sqlite3_errmsg(@db.value_with_autorelease) if result != SQLITE_OK
     end
   end
 end


### PR DESCRIPTION
🚨 This includes breaking changes, so we'll need to do a version bump. 🚨 

_Fixes a memory leak issue that existed since the early days of RM_